### PR TITLE
[APIS-804] Set g++ as Linux64 compiler for cci

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ AM_CONDITIONAL([BUILD_64], [test "$enable_64bit" = "yes"])
 OBJECT_MODE=""
 case $SYSTEM_TYPE in
 	*linux*) 
+		CC=g++
 		if test "$enable_64bit" = "yes"
 		then
 		  BIT_MODEL="-m64"


### PR DESCRIPTION
If we build cci library using gcc, we have like problem on Linux apps, for example, perl, PHP.
Set the compiler as g++ in Linux