### PR TITLE
[APIS-804] Change regex include path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -660,7 +660,7 @@ AC_MSG_RESULT([$with_cmserver])
 
 AC_CONFIG_SUBDIRS([external/libregex38a])
 REGEX_LIBS="\$(top_builddir)/external/libregex38a/libregex38a.la"
-REGEX_INC="-I\$(top_builddir)/external/include/libregex38a"
+REGEX_INC="-I\$(top_builddir)/external/include"
 EXTERNAL_PKGS="$EXTERNAL_PKGS libregex38a"
 
 AC_MSG_CHECKING([for expat library])
@@ -969,7 +969,7 @@ AS_IF([test "$with_cci_only" = "yes"],
 	EXTRA_DIST_SUBDIRS=""
 	CUBRID_LOGDIR=""
 	CUBRID_TMPDIR=""],
-	[BUILD_SUBDIRS="external include cas sa cs cubrid util cci broker cm_common conf msg demo contrib locales tools timezones $OPTIONAL_DIR"
+	[BUILD_SUBDIRS="external cas sa cs cubrid util cci broker cm_common conf msg demo contrib locales tools timezones $OPTIONAL_DIR"
 	EXTRA_DIST_SUBDIRS="debian win src"])
 
 AC_SUBST([BUILD_NUMBER])


### PR DESCRIPTION
1.  Unfortunately, our development Linux has a file /usr/local/include/libregex38a/regex38a.h,
somebody found bad include path during driver conformance test.
* in cubrid-cci there is a include reference like: 
      #include "libregex38a/regex38a.h"
* In cci-repo, regex38a.h is located in 'external/libregex38a/include/regex38a.h' which result in "cannot find regex38a.h" during compilation
* However, if a build system has regex38a.h in /usr/local, build system will use that file to include. This is not expected, include path should be modified.
2. exclude "include" from BUILD_SUBDIRS: it is due to skip include file consistency check for
      files in directory {cci_repo}/include to check consistencies for 'error codes','statement types' and isolation types.