### PR TITLE
[CBRD-23840] Separation/Integration of cci repositories from CUBRID repository.

### DIFF
--- a/cci/CMakeLists.txt
+++ b/cci/CMakeLists.txt
@@ -186,9 +186,9 @@ if(WIN32)
   target_link_libraries(cascci LINK_PRIVATE ws2_32)
 endif(WIN32)
 
-if(NOT ${EP_TARGETS} STREQUAL "")
+if(NOT "${EP_TARGETS}" STREQUAL "")
   add_dependencies(cascci ${EP_TARGETS})
-endif(NOT ${EP_TARGETS} STREQUAL "")
+endif(NOT "${EP_TARGETS}" STREQUAL "")
 
 install(TARGETS cascci
   RUNTIME DESTINATION ${CUBRID_CCIDIR}/bin COMPONENT CCI


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-23949

- If {EP_TARGET} contains space , error occurs in cmake.