### PR TITLE
[APIS-882] cci unintentionally changes bind type short/ushort to int/uint and sends it to CAS

### DIFF
--- a/src/cci/cci_query_execute.c
+++ b/src/cci/cci_query_execute.c
@@ -6558,22 +6558,16 @@ bind_value_conversion (T_CCI_A_TYPE a_type, T_CCI_U_TYPE u_type, char flag, void
     }
 
   bind_value->u_type = u_type;
-  if (u_type == CCI_U_TYPE_SHORT)
-    {
-      bind_value->u_type = CCI_U_TYPE_INT;
-    }
-  else if (u_type == CCI_U_TYPE_USHORT)
-    {
-      bind_value->u_type = CCI_U_TYPE_UINT;
-    }
 
   switch (u_type)
     {
-    case CCI_U_TYPE_SHORT:
     case CCI_U_TYPE_INT:
-    case CCI_U_TYPE_USHORT:
     case CCI_U_TYPE_UINT:
       bind_value->size = NET_SIZE_INT;
+      break;
+    case CCI_U_TYPE_SHORT:
+    case CCI_U_TYPE_USHORT:
+      bind_value->size = NET_SIZE_SHORT;
       break;
     case CCI_U_TYPE_BIGINT:
     case CCI_U_TYPE_UBIGINT:
@@ -6699,9 +6693,7 @@ bind_value_to_net_buf (T_NET_BUF * net_buf, T_CCI_U_TYPE u_type, void *value, in
 	}
       break;
     case CCI_U_TYPE_INT:
-    case CCI_U_TYPE_SHORT:
     case CCI_U_TYPE_UINT:
-    case CCI_U_TYPE_USHORT:
       if (value == NULL)
 	{
 	  ADD_ARG_INT (net_buf, 0);
@@ -6709,6 +6701,17 @@ bind_value_to_net_buf (T_NET_BUF * net_buf, T_CCI_U_TYPE u_type, void *value, in
       else
 	{
 	  ADD_ARG_INT (net_buf, *((int *) value));
+	}
+      break;
+    case CCI_U_TYPE_SHORT:
+    case CCI_U_TYPE_USHORT:
+      if (value == NULL)
+	{
+	  ADD_ARG_SHORT (net_buf, 0);
+	}
+      else
+	{
+	  ADD_ARG_SHORT (net_buf, *((short *) value));
 	}
       break;
     case CCI_U_TYPE_FLOAT:

--- a/src/cci/cci_query_execute.h
+++ b/src/cci/cci_query_execute.h
@@ -225,6 +225,12 @@
 	  (OBJ_VAL).volid = macro_var_volid;		        \
 	} while (0)
 
+#define ADD_ARG_SHORT(BUF, VALUE)			\
+	do {					\
+	  net_buf_cp_int((BUF), NET_SIZE_SHORT);	\
+	  net_buf_cp_short((BUF), (VALUE));	\
+	} while (0)
+
 #define ADD_ARG_INT(BUF, VALUE)			\
 	do {					\
 	  net_buf_cp_int((BUF), NET_SIZE_INT);	\


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-882

**Purpose**
When CCI_U_TYPE_SHORT is assigned to u_type of cci_bind_param() function, CCI sends CCI_U_TYPE_INT to CAS instead of CCI_U_TYPE_SHORT.
As a result, CAS receives the wrong type, CCI_U_TYPE_INT, instead of CCI_U_TYPE_SHORT.
This behavior can lead to errors in some situations, for example CAS Gateway to ODBC.

Since CCI_U_TYPE_INT and CCI_U_TYPE_SHORT are different types, they must be separated from each other.

**Implementation**
N/A

**Remarks**
N/A