### PR TITLE
[CBRD-24242] If is_fetch_completed of the EXECUTE protocol is 1, the fetch request is not made.

### DIFF
--- a/src/cci/cci_query_execute.c
+++ b/src/cci/cci_query_execute.c
@@ -1457,8 +1457,7 @@ qe_cursor (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, int offset, cha
 		  return CCI_ER_NO_MORE_DATA;
 		}
 
-	      if (is_connected_to_oracle (con_handle) && cursor_pos > req_handle->fetched_tuple_end
-		  && req_handle->is_fetch_completed)
+	      if (cursor_pos > req_handle->fetched_tuple_end && req_handle->is_fetch_completed)
 		{
 		  return CCI_ER_NO_MORE_DATA;
 		}
@@ -1668,8 +1667,7 @@ qe_fetch (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, char flag, int r
     }
   else
     {
-      if (is_connected_to_oracle (con_handle) && req_handle->cursor_pos > req_handle->fetched_tuple_end
-	  && req_handle->is_fetch_completed)
+      if (req_handle->cursor_pos > req_handle->fetched_tuple_end && req_handle->is_fetch_completed)
 	{
 	  return CCI_ER_NO_MORE_DATA;
 	}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24242

Purpose
When using ODBC Gateway, ODBC does not provide the row count of query results, so the total row count cannot be sent to the driver. In this case, an error occurs in the Driver.
However, CAS sends is_fetch_completed set to 1 to the driver when it can no longer send query results.
Although the driver makes a request to CAS as many as the total row count, fetch can be terminated when is_fetch_completed is 1 even if the total rows count is unknown.

Implementation
N/A

Remarks
N/A