### PR TITLE
[APIS-908] Add client_type for connection to ODBC Gateway

### DIFF
--- a/src/cci/broker_cas_protocol.h
+++ b/src/cci/broker_cas_protocol.h
@@ -71,7 +71,8 @@ extern "C"
     CAS_CLIENT_PHP = 4,
     CAS_CLIENT_OLEDB = 5,
     CAS_CLIENT_SERVER_SIDE_JDBC = 6,
-    CAS_CLIENT_TYPE_MAX = 6
+    CAS_CLIENT_GATEWAY = 7,
+    CAS_CLIENT_TYPE_MAX = 7
   } CAS_CLIENT_TYPE;
 
   typedef enum
@@ -264,18 +265,18 @@ extern "C"
 
 #define CAS_TYPE_FIRST_BYTE_PROTOCOL_MASK 0x80
 
-typedef int T_BROKER_VERSION;
+  typedef int T_BROKER_VERSION;
 
 #ifdef __cplusplus
 }
 #endif
 
  /*
- * CAUTION!
- *
- * In case of common,  
- * engine source (src/broker/cas_protocol.h) must be updated,
- * becuase CCI source and Engine source have been separated.
- */
+  * CAUTION!
+  *
+  * In case of common,  
+  * engine source (src/broker/cas_protocol.h) must be updated,
+  * becuase CCI source and Engine source have been separated.
+  */
 
 #endif				/* _BROKER_CAS_PROTOCOL_H_ */

--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -341,7 +341,8 @@ int
 cci_get_version (int *major, int *minor, int *patch)
 {
 #ifdef CCI_DEBUG
-  CCI_DEBUG_PRINT (print_debug_msg ("cci_get_version:%d.%d.%d", CCI_MAJOR_VERSION, CCI_MINOR_VERSION, CCI_PATCH_VERSION));
+  CCI_DEBUG_PRINT (print_debug_msg
+		   ("cci_get_version:%d.%d.%d", CCI_MAJOR_VERSION, CCI_MINOR_VERSION, CCI_PATCH_VERSION));
 #endif
 
   if (major)
@@ -6659,4 +6660,10 @@ cci_get_cas_info (int mapped_conn_id, char *info_buf, int buf_length, T_CCI_ERRO
   con_handle->used = false;
 
   return error;
+}
+
+void
+cci_set_client_type (int client_type)
+{
+  net_set_client_type (client_type);
 }

--- a/src/cci/cas_cci.h
+++ b/src/cci/cas_cci.h
@@ -248,6 +248,8 @@
 
 #define CCI_TZ_SIZE 63
 
+#define CLIENT_TYPE_GATEWAY    7
+
 /* for cci auto_comit mode support */
 typedef enum
 {
@@ -977,6 +979,7 @@ extern "C"
 				    char *attr_name, char flag, T_CCI_ERROR * err_buf);
   extern int cci_is_shard (int con_h_id, T_CCI_ERROR * err_buf);
   extern int cci_get_cas_info (int mapped_conn_id, char *info_buf, int buf_length, T_CCI_ERROR * err_buf);
+  extern void cci_set_client_type (int client_type);
 
 #ifdef __cplusplus
 }

--- a/src/cci/cci_network.c
+++ b/src/cci/cci_network.c
@@ -1642,3 +1642,9 @@ ssl_session_init (T_CON_HANDLE * con_handle, SOCKET sock_fd)
   con_handle->ssl_handle.is_connected = true;
   return err_code;
 }
+
+void
+net_set_client_type (int client_type)
+{
+  cci_client_type = client_type;
+}

--- a/src/cci/cci_network.h
+++ b/src/cci/cci_network.h
@@ -95,6 +95,7 @@ extern int net_cancel_request (T_CON_HANDLE * con_handle);
 extern int net_check_cas_request (T_CON_HANDLE * con_handle);
 extern bool net_peer_alive (unsigned char *ip_addr, int port, int timeout_msec);
 extern bool net_check_broker_alive (unsigned char *ip_addr, int port, int timeout_msec, char useSSL);
+extern void net_set_client_type (int client_type);
 /************************************************************************
  * EXPORTED VARIABLES							*
  ************************************************************************/

--- a/win/cascci/cascci.def
+++ b/win/cascci/cascci.def
@@ -107,6 +107,7 @@ EXPORTS
 	cci_set_holdability
 	cci_get_holdability
 	cci_get_cas_info
+	cci_set_client_type
 	
 	cci_log_get
 	cci_log_finalize


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-908

Purpose
To connect to ODBC Gateway, anyone can connect using the port number set in cubrid_gateway.conf and the IP where ODBC Gateway is installed.
ODBC Gateway only accepts connection requests from DBLink Server, and when a connection request comes in, it is necessary to determine whether a connection request has come from DBLink Server.
To make this judgment, client_type for ODBC Gateway was added.
DBLink Server can connect only when Client_Type is set to CAS_CLIENT_GATEWAY.

Implementation
Add cci_set_client_type(int client_type)

Remarks
N/A