### PR TITLE
[CBRD-24271] Modify build environment for drivers that use the CCI driver source or file.

### DIFF
--- a/src/cci/cas_cci.h
+++ b/src/cci/cas_cci.h
@@ -51,6 +51,7 @@
  * IMPORTED OTHER HEADER FILES						*
  ************************************************************************/
 #include "compat_dbtran_def.h"
+#include "broker_cas_error.h"
 
 /************************************************************************
  * EXPORTED DEFINITIONS							*


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24271

Purpose
- add include broker_cas_error.h in cas_cci.h (qa team request - compatibility with earlier versions)

Implementation
N/A

Remarks
N/A