### PR TITLE
[APIS-911] Add connection property to connect to Gateway

### DIFF
--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -6661,9 +6661,3 @@ cci_get_cas_info (int mapped_conn_id, char *info_buf, int buf_length, T_CCI_ERRO
 
   return error;
 }
-
-void
-cci_set_client_type (int client_type)
-{
-  net_set_client_type (client_type);
-}

--- a/src/cci/cas_cci.h
+++ b/src/cci/cas_cci.h
@@ -249,8 +249,6 @@
 
 #define CCI_TZ_SIZE 63
 
-#define CLIENT_TYPE_GATEWAY    7
-
 /* for cci auto_comit mode support */
 typedef enum
 {
@@ -980,7 +978,6 @@ extern "C"
 				    char *attr_name, char flag, T_CCI_ERROR * err_buf);
   extern int cci_is_shard (int con_h_id, T_CCI_ERROR * err_buf);
   extern int cci_get_cas_info (int mapped_conn_id, char *info_buf, int buf_length, T_CCI_ERROR * err_buf);
-  extern void cci_set_client_type (int client_type);
 
 #ifdef __cplusplus
 }

--- a/src/cci/cci_handle_mng.c
+++ b/src/cci/cci_handle_mng.c
@@ -1324,6 +1324,7 @@ init_con_handle (T_CON_HANDLE * con_handle, char *ip_str, int port, char *db_nam
   con_handle->ssl_handle.ssl = NULL;
   con_handle->ssl_handle.ctx = NULL;
   con_handle->useSSL = false;
+  con_handle->__gateway = false;
   con_handle->deferred_max_close_handle_count = DEFERRED_CLOSE_HANDLE_ALLOC_SIZE;
   con_handle->deferred_close_handle_list = (int *) MALLOC (sizeof (int) * con_handle->deferred_max_close_handle_count);
   con_handle->deferred_close_handle_count = 0;
@@ -1335,7 +1336,6 @@ init_con_handle (T_CON_HANDLE * con_handle, char *ip_str, int port, char *db_nam
   con_handle->shard_id = CCI_SHARD_ID_INVALID;
 
   con_handle->ssl_handle.is_connected = false;
-  con_handle->is_gateway_client = 0;
   return 0;
 }
 

--- a/src/cci/cci_handle_mng.h
+++ b/src/cci/cci_handle_mng.h
@@ -258,6 +258,7 @@ typedef struct
   char log_trace_api;
   char log_trace_network;
   char useSSL;
+  char __gateway;
 
   /* to check timeout */
   struct timeval start_time;	/* function start time to check timeout */
@@ -276,8 +277,6 @@ typedef struct
 
   /* ssl */
   T_SSL_HANDLE ssl_handle;
-
-  int is_gateway_client;
 
 } T_CON_HANDLE;
 

--- a/src/cci/cci_network.c
+++ b/src/cci/cci_network.c
@@ -178,8 +178,6 @@ net_connect_srv (T_CON_HANDLE * con_handle, int host_id, T_CCI_ERROR * err_buf, 
   memset (client_info, 0, sizeof (client_info));
   memset (db_info, 0, sizeof (db_info));
 
-  con_handle->is_gateway_client = cci_client_type;
-
   if (con_handle->useSSL == USESSL)
     {
       memcpy (client_info, SRV_CON_CLIENT_MAGIC_STR_SSL, SRV_CON_CLIENT_MAGIC_LEN);
@@ -1643,10 +1641,4 @@ ssl_session_init (T_CON_HANDLE * con_handle, SOCKET sock_fd)
 
   con_handle->ssl_handle.is_connected = true;
   return err_code;
-}
-
-void
-net_set_client_type (int client_type)
-{
-  cci_client_type = client_type;
 }

--- a/src/cci/cci_network.h
+++ b/src/cci/cci_network.h
@@ -95,7 +95,6 @@ extern int net_cancel_request (T_CON_HANDLE * con_handle);
 extern int net_check_cas_request (T_CON_HANDLE * con_handle);
 extern bool net_peer_alive (unsigned char *ip_addr, int port, int timeout_msec);
 extern bool net_check_broker_alive (unsigned char *ip_addr, int port, int timeout_msec, char useSSL);
-extern void net_set_client_type (int client_type);
 /************************************************************************
  * EXPORTED VARIABLES							*
  ************************************************************************/

--- a/src/cci/cci_properties.c
+++ b/src/cci/cci_properties.c
@@ -357,6 +357,7 @@ cci_conn_set_properties (T_CON_HANDLE * handle, char *properties)
     {"disconnect_on_query_timeout", BOOL_PROPERTY,
      &handle->disconnect_on_query_timeout},
     {"useSSL", BOOL_PROPERTY, &handle->useSSL},
+    {"__gateway", BOOL_PROPERTY, &handle->__gateway}
   };
   int error = CCI_ER_NO_ERROR;
 

--- a/src/cci/cci_query_execute.c
+++ b/src/cci/cci_query_execute.c
@@ -1457,7 +1457,7 @@ qe_cursor (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, int offset, cha
 		  return CCI_ER_NO_MORE_DATA;
 		}
 
-	      if ((is_connected_to_oracle (con_handle) || con_handle->is_gateway_client == CLIENT_TYPE_GATEWAY)
+	      if ((is_connected_to_oracle (con_handle) || con_handle->__gateway == true)
 		  && cursor_pos > req_handle->fetched_tuple_end && req_handle->is_fetch_completed)
 		{
 		  return CCI_ER_NO_MORE_DATA;
@@ -1668,7 +1668,7 @@ qe_fetch (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, char flag, int r
     }
   else
     {
-      if ((is_connected_to_oracle (con_handle) || con_handle->is_gateway_client == CLIENT_TYPE_GATEWAY)
+      if ((is_connected_to_oracle (con_handle) || con_handle->__gateway == true)
 	  && req_handle->cursor_pos > req_handle->fetched_tuple_end && req_handle->is_fetch_completed)
 	{
 	  return CCI_ER_NO_MORE_DATA;

--- a/win/cascci/cascci.def
+++ b/win/cascci/cascci.def
@@ -107,7 +107,6 @@ EXPORTS
 	cci_set_holdability
 	cci_get_holdability
 	cci_get_cas_info
-	cci_set_client_type
 	
 	cci_log_get
 	cci_log_finalize


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-911

Purpose
For DBLink Server to connect to the Gateway, __gateway property has been added.
When DBLink Server tries to connect to the Gateway, it must use the __gateway property to connect to the Gateway.

Implementation
N/A

Remarks
N/A