### PR TITLE
[CBRD-24453] Check the CCI driver file related to engine build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,14 @@ cmake_minimum_required(VERSION 2.8)
 
 if(WITH_CCI)
 message(STATUS "======== WITH_CCI ==========")
+
+set(CCI_BASE_DIR                 ${CMAKE_CURRENT_SOURCE_DIR}/src/base)
+set(CCI_DIR                      ${CMAKE_CURRENT_SOURCE_DIR}/src/cci)
+set(CCI_TOOLS_DIR                ${CMAKE_CURRENT_SOURCE_DIR}/src/tools)
+
 add_subdirectory(cci)
 add_subdirectory(tools)
+
 else(WITH_CCI)
 message(STATUS "======== CCI REPO MAKE ==========") 
 #also searches for modules onto cubrid/cmake
@@ -174,9 +180,9 @@ endif()
 message(STATUS "Build ${PROJECT_NAME} ${CUBRID_VERSION} ${TARGET_PLATFORM_BITS}bit ${CMAKE_BUILD_TYPE} on ${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR}")
 
 # source directories
-set(BASE_DIR                 ${CMAKE_SOURCE_DIR}/src/base)
+set(CCI_BASE_DIR                 ${CMAKE_SOURCE_DIR}/src/base)
 set(CCI_DIR                  ${CMAKE_SOURCE_DIR}/src/cci)
-set(TOOLS_DIR                ${CMAKE_SOURCE_DIR}/src/tools)
+set(CCI_TOOLS_DIR                ${CMAKE_SOURCE_DIR}/src/tools)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(

--- a/cci/CMakeLists.txt
+++ b/cci/CMakeLists.txt
@@ -17,7 +17,7 @@
 #
 
 set(CASCCI_SOURCES
-  ${BASE_DIR}/porting.c
+  ${CCI_BASE_DIR}/porting.c
   ${CCI_DIR}/cas_cci.c
   ${CCI_DIR}/cci_util.c
   ${CCI_DIR}/cci_query_execute.c
@@ -34,7 +34,7 @@ set(CASCCI_SOURCES
   )
 if(WIN32)
   list(APPEND CASCCI_SOURCES ${CCI_DIR}/cci_wsa_init.c)
-  list(APPEND CASCCI_SOURCES ${BASE_DIR}/rand.c)
+  list(APPEND CASCCI_SOURCES ${CCI_BASE_DIR}/rand.c)
 endif(WIN32)
 
 SET_SOURCE_FILES_PROPERTIES(
@@ -196,7 +196,7 @@ if(WIN32)
   else(FOR_OTHER_DRIVER)
     target_compile_definitions(cascci PRIVATE CAS_CCI_DL)
   endif(FOR_OTHER_DRIVER)
-  set_target_properties(cascci PROPERTIES LINK_FLAGS "/DEF:\"${CMAKE_SOURCE_DIR}/win/cascci/cascci.def\"" LINK_FLAGS_RELEASE "/NODEFAULTLIB:libcmt.lib" LINK_FLAGS_DEBUG "/NODEFAULTLIB:msvcrt.lib")
+  set_target_properties(cascci PROPERTIES LINK_FLAGS "/DEF:\"${CCI_ROOT_PATH}/win/cascci/cascci.def\"" LINK_FLAGS_RELEASE "/NODEFAULTLIB:libcmt.lib" LINK_FLAGS_DEBUG "/NODEFAULTLIB:msvcrt.lib")
   target_link_libraries(cascci LINK_PRIVATE ws2_32)
 endif(WIN32)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -18,8 +18,8 @@
 
 if(UNIX)
   set(CCI_APPLIER_SOURCES
-    ${TOOLS_DIR}/cci_applier.c
-    ${BASE_DIR}/cubrid_getopt_long.c
+    ${CCI_TOOLS_DIR}/cci_applier.c
+    ${CCI_BASE_DIR}/cubrid_getopt_long.c
     )
   SET_SOURCE_FILES_PROPERTIES(
     ${CCI_APPLIER_SOURCES}


### PR DESCRIPTION
http://jira.cubrid.org/browse/CBRD-24453

Purpose
Check the CCI driver file related to engine build.

Implementation

- Change CCI Driver to use 'cascci.def' in 'cubrid-cci' repository
cubrid/win/cascci.def -> cubrid/cubrid-cci/win/cascci.def
- On build for engine, modify to use CCI BASE(cubic-cci/src/base) folder.

Remarks
After the merge is completed, the file in engine Repository is also modified.