### PR TITLE
[APIS-945] Fix the core dump error related with CCI Connection Pool

### DIFF
--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -132,6 +132,9 @@ int wsa_initialize ();
 #define CON_HANDLE_ID_FACTOR            1000000
 #define CON_ID(a) ((a) / CON_HANDLE_ID_FACTOR)
 #define REQ_ID(a) ((a) % CON_HANDLE_ID_FACTOR)
+
+#define MAX_CON_HANDLE                  2048
+
 /************************************************************************
  * PRIVATE FUNCTION PROTOTYPES						*
  ************************************************************************/
@@ -719,7 +722,7 @@ cci_disconnect (int mapped_conn_id, T_CCI_ERROR * err_buf)
 	  cci_end_tran_internal (con_handle, CCI_TRAN_ROLLBACK);
 
 	  MUTEX_LOCK (con_handle_table_mutex);
-	  if (con_handle->id >= 0 && hm_put_con_to_pool (con_handle->id) >= 0)
+	  if ((con_handle->id >= 1 && con_handle->id <= MAX_CON_HANDLE) && hm_put_con_to_pool (con_handle->id) >= 0)
 	    {
 	      API_ELOG (con_handle, 0);
 	      get_last_error (con_handle, err_buf);

--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -133,8 +133,6 @@ int wsa_initialize ();
 #define CON_ID(a) ((a) / CON_HANDLE_ID_FACTOR)
 #define REQ_ID(a) ((a) % CON_HANDLE_ID_FACTOR)
 
-#define MAX_CON_HANDLE                  2048
-
 /************************************************************************
  * PRIVATE FUNCTION PROTOTYPES						*
  ************************************************************************/

--- a/src/cci/cci_handle_mng.c
+++ b/src/cci/cci_handle_mng.c
@@ -187,17 +187,6 @@ hm_put_con_to_pool (int con)
 }
 
 int
-hm_put_con_to_pool_exceed (void)
-{
-  if (num_conn_pool >= sizeof (conn_pool) / sizeof (int))
-    {
-      return -1;
-    }
-
-  return 0;
-}
-
-int
 hm_ip_str_to_addr (char *ip_str, unsigned char *ip_addr)
 {
   if (is_ip_str (ip_str))

--- a/src/cci/cci_handle_mng.c
+++ b/src/cci/cci_handle_mng.c
@@ -187,6 +187,17 @@ hm_put_con_to_pool (int con)
 }
 
 int
+hm_put_con_to_pool_exceed (void)
+{
+  if (num_conn_pool >= sizeof (conn_pool) / sizeof (int))
+    {
+      return -1;
+    }
+
+  return 0;
+}
+
+int
 hm_ip_str_to_addr (char *ip_str, unsigned char *ip_addr)
 {
   if (is_ip_str (ip_str))

--- a/src/cci/cci_handle_mng.c
+++ b/src/cci/cci_handle_mng.c
@@ -72,8 +72,6 @@
  * PRIVATE DEFINITIONS							*
  ************************************************************************/
 
-#define MAX_CON_HANDLE                  2048
-
 #define REQ_HANDLE_ALLOC_SIZE           256
 
 #define CCI_MAX_CONNECTION_POOL         256

--- a/src/cci/cci_handle_mng.h
+++ b/src/cci/cci_handle_mng.h
@@ -314,6 +314,7 @@ extern int hm_ip_str_to_addr (char *ip_str, unsigned char *ip_addr);
 extern T_CON_HANDLE *hm_get_con_from_pool (unsigned char *ip_addr, int port, char *dbname, char *dbuser,
 					   char *dbpasswd);
 extern int hm_put_con_to_pool (int con);
+extern int hm_put_con_to_pool_exceed (void);
 
 extern T_BROKER_VERSION hm_get_broker_version (T_CON_HANDLE * con_handle);
 extern bool hm_broker_understand_renewed_error_code (T_CON_HANDLE * con_handle);

--- a/src/cci/cci_handle_mng.h
+++ b/src/cci/cci_handle_mng.h
@@ -314,7 +314,6 @@ extern int hm_ip_str_to_addr (char *ip_str, unsigned char *ip_addr);
 extern T_CON_HANDLE *hm_get_con_from_pool (unsigned char *ip_addr, int port, char *dbname, char *dbuser,
 					   char *dbpasswd);
 extern int hm_put_con_to_pool (int con);
-extern int hm_put_con_to_pool_exceed (void);
 
 extern T_BROKER_VERSION hm_get_broker_version (T_CON_HANDLE * con_handle);
 extern bool hm_broker_understand_renewed_error_code (T_CON_HANDLE * con_handle);

--- a/src/cci/cci_handle_mng.h
+++ b/src/cci/cci_handle_mng.h
@@ -83,6 +83,9 @@
 
 #define REACHABLE       true
 #define UNREACHABLE     false
+
+#define MAX_CON_HANDLE                  2048
+
 /************************************************************************
  * PUBLIC TYPE DEFINITIONS						*
  ************************************************************************/


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-945

**Purpose**

- When CCI PCONNECT is used in the multi-thread environment, it must be guaranteed that application is executed whether it works failed or success. But core dump error occurs, it is required to execute the application in the multi-thread environment.

**Implementation**

- Fix the core dump error

**Remarks**

N/A