### PR TITLE
[APIS-949] extend CCI max connections up to 4,096 per process

### DIFF
--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -129,7 +129,6 @@ int wsa_initialize ();
 #define CCI_DS_USESSL_DEFAULT 	false
 
 
-#define CON_HANDLE_ID_FACTOR            1000000
 #define CON_ID(a) ((a) / CON_HANDLE_ID_FACTOR)
 #define REQ_ID(a) ((a) % CON_HANDLE_ID_FACTOR)
 

--- a/src/cci/cas_cci.h
+++ b/src/cci/cas_cci.h
@@ -209,7 +209,7 @@
 #define SSIZEOF(val) ((ssize_t) sizeof(val))
 #endif
 
-#define CON_HANDLE_ID_FACTOR		1000000
+#define CON_HANDLE_ID_FACTOR		500000
 
 #define GET_CON_ID(H) ((H) / CON_HANDLE_ID_FACTOR)
 #define GET_REQ_ID(H) ((H) % CON_HANDLE_ID_FACTOR)

--- a/src/cci/cci_handle_mng.h
+++ b/src/cci/cci_handle_mng.h
@@ -84,7 +84,7 @@
 #define REACHABLE       true
 #define UNREACHABLE     false
 
-#define MAX_CON_HANDLE                  2048
+#define MAX_CON_HANDLE                  4096
 
 /************************************************************************
  * PUBLIC TYPE DEFINITIONS						*


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-949

**Purpose**
* CUBRID Engine allows connections of up to 4000 clients ([cubrid.conf] max_client=4000).
* On the other hand, CUBRID CCI allows up to 2,048 connections per process.
* We want to allow up to 4096 CCI connections per process.

**Implementation**
N/A

**Remarks**
To generate handle ID, it multiplies connection handle_id by **CON_HANDLE_ID_FACTOR** and adds req_handle_id to it.
4096 * 1000000 = 4096000000, this exceeds **integer MAX**. 
4096 * 500000  = 2048000000. For this reason, CON_HANDLE_ID_FACTOR has been modified.
* refer cas_cci.h:216
`#define MAKE_REQ_ID(C,R) ((C) * CON_HANDLE_ID_FACTOR + (R))`