### PR TITLE
[APIS-955] fix CLOSET_SOCKET macro

### DIFF
--- a/src/cci/cci_common.h
+++ b/src/cci/cci_common.h
@@ -131,8 +131,11 @@
 	  struct linger linger_buf;	\
 	  linger_buf.l_onoff = 1;	\
 	  linger_buf.l_linger = 0;	\
-	  setsockopt(X, SOL_SOCKET, SO_LINGER, (char *) &linger_buf, sizeof(linger_buf));	\
-	  closesocket(X);		\
+	  if (!IS_INVALID_SOCKET(X)) {	\
+	    setsockopt(X, SOL_SOCKET, SO_LINGER, (char *) &linger_buf, sizeof(linger_buf));	\
+	    closesocket(X);		\
+	    (X) = INVALID_SOCKET;	\
+	  }				\
 	} while (0)
 #else
 #define CLOSE_SOCKET(X)			\
@@ -140,8 +143,11 @@
 	  struct linger linger_buf;	\
 	  linger_buf.l_onoff = 1;	\
 	  linger_buf.l_linger = 0;	\
-	  setsockopt(X, SOL_SOCKET, SO_LINGER, (char *) &linger_buf, sizeof(linger_buf));	\
-	  close(X);			\
+	  if (!IS_INVALID_SOCKET(X)) {	\
+	    setsockopt(X, SOL_SOCKET, SO_LINGER, (char *) &linger_buf, sizeof(linger_buf));	\
+	    close(X);			\
+	    (X) = INVALID_SOCKET;	\
+	  }				\
 	} while (0)
 #endif
 

--- a/src/cci/cci_network.c
+++ b/src/cci/cci_network.c
@@ -456,7 +456,7 @@ net_connect_srv (T_CON_HANDLE * con_handle, int host_id, T_CCI_ERROR * err_buf, 
 
 connect_srv_error:
   hm_ssl_free (con_handle);
-  CLOSE_SOCKET (srv_sock_fd);
+  CLOSE_SOCKET (con_handle->sock_fd);
   return err_code;
 }
 

--- a/src/cci/cci_network.c
+++ b/src/cci/cci_network.c
@@ -290,7 +290,7 @@ net_connect_srv (T_CON_HANDLE * con_handle, int host_id, T_CCI_ERROR * err_buf, 
 
   if (new_port != port && new_port > 0)
     {
-      CLOSE_SOCKET (srv_sock_fd);
+      CLOSE_SOCKET (con_handle->sock_fd);
 
       ret_value = connect_srv (ip_addr, new_port, con_handle->is_retry, &srv_sock_fd, login_timeout);
       if (ret_value < 0)


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-955

**Description**
* When a cci handle is returned, `hm_con_handle_free()` closes the connected socket associated with the cci handle.
* If the **socket descriptor** associated with the **cci handle** is a value other than -1, the connection is closed regardless of whether it was **created by another thread**.
* When net_connect_srv () received negative answer from the CAS, it should not only close that connection, but also set the sd connected to the relevant cci handle to -1 (**INVALID_SOCKET**).
* If not, a socket **created by another thread** could be closed.