### PR TITLE
[APIS-956] fix to pickup a connection with same ssl property in the connection pool

### DIFF
--- a/src/cci/cci_handle_mng.h
+++ b/src/cci/cci_handle_mng.h
@@ -288,7 +288,7 @@ typedef struct
  ************************************************************************/
 
 extern void hm_con_handle_table_init (void);
-extern T_CON_HANDLE *hm_con_handle_alloc (char *ip_str, int port, char *db_name, char *db_user, char *db_passwd);
+extern T_CON_HANDLE *hm_con_handle_alloc (char *ip_str, int port, char *db_name, char *db_user, char *db_passwd, bool useSSL);
 extern int hm_req_handle_alloc (T_CON_HANDLE * connection, T_REQ_HANDLE ** statement);
 extern void hm_req_handle_free (T_CON_HANDLE * con_handle, T_REQ_HANDLE * req_handle);
 extern void hm_req_handle_free_all (T_CON_HANDLE * con_handle);
@@ -315,7 +315,7 @@ extern int req_close_query_result (T_REQ_HANDLE * req_handle);
 extern void hm_invalidate_all_req_handle (T_CON_HANDLE * con_handle);
 extern int hm_ip_str_to_addr (char *ip_str, unsigned char *ip_addr);
 extern T_CON_HANDLE *hm_get_con_from_pool (unsigned char *ip_addr, int port, char *dbname, char *dbuser,
-					   char *dbpasswd);
+					   char *dbpasswd, bool useSSL);
 extern int hm_put_con_to_pool (int con);
 
 extern T_BROKER_VERSION hm_get_broker_version (T_CON_HANDLE * con_handle);
@@ -349,6 +349,8 @@ extern void hm_make_empty_session (T_CCI_SESSION_ID * id);
 extern void hm_force_close_connection (T_CON_HANDLE * con_handle);
 
 extern void hm_ssl_free (T_CON_HANDLE * con_handle);
+
+extern bool has_ssl_property (char *prop);
 /************************************************************************
  * PUBLIC VARIABLES							*
  ************************************************************************/

--- a/src/cci/cci_properties.c
+++ b/src/cci/cci_properties.c
@@ -444,3 +444,27 @@ set_properties_end:
   API_ELOG (handle, error);
   return error;
 }
+
+bool
+has_ssl_property (char *prop)
+{
+  char useSSL;
+  char buf[4096] = { 0, };
+  T_URL_PROPERTY props[] = {
+    {"useSSL", BOOL_PROPERTY, &useSSL},
+  };
+
+  if (prop == NULL)
+    {
+      return false;
+    }
+
+  snprintf (buf, sizeof (buf), "%s", prop);
+
+  if (cci_url_parse_properties (props, DIM (props), buf) != CCI_ER_NO_ERROR)
+    {
+      return false;
+    }
+
+  return useSSL;
+}


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-956

**Description**
* If **PCONNECT=ON** is set in the **cubrid_broker.conf** for a broker, a cci apps can pickup a connection in the connection pool rather than make a new connection
* currently we pick up a connection from the connection pool that matches the following args:
  * ipAddr
  * port
  * dbname
  * dbuser name
  * db password
* In addition to this, we have to check '**useSSL**' property also