### PR TITLE
[APIS-956] set default SSL mode to false

### DIFF
--- a/src/cci/cci_properties.c
+++ b/src/cci/cci_properties.c
@@ -448,7 +448,7 @@ set_properties_end:
 bool
 has_ssl_property (char *prop)
 {
-  char useSSL;
+  char useSSL = false;
   char buf[4096] = { 0, };
   T_URL_PROPERTY props[] = {
     {"useSSL", BOOL_PROPERTY, &useSSL},


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-956

**Description**
* in addition to #67,
* set default SSL mode to false if not specified in CCI property