### PR TITLE
[APIS-967] [regression-rev] Changed the way the float type removes trailing zeroes

### DIFF
--- a/src/cci/cci_util.c
+++ b/src/cci/cci_util.c
@@ -838,7 +838,7 @@ ut_float_to_str_with_remove_trailingzeros (float value, char *str, int size)
 
   char *dot, *exp, *sp = return_str + 1;
 
-  snprintf (float_str, sizeof (float_str), "%g", fabsf (value));
+  snprintf (float_str, sizeof (float_str), "%.7g", fabsf (value));
   dot = strchr (float_str, '.');
   exp = strchr (float_str, 'e');
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-967

Purpose
In float type, we should %.7g instead of %g for proper mantissa fraction.

Implementation
N/A

Remarks
N/A