### PR TITLE
[APIS-977] CCI receives the oracle_compat_number_behavior system parameter and removes trailing zeros of double and float types

### DIFF
--- a/src/cci/broker_cas_protocol.h
+++ b/src/cci/broker_cas_protocol.h
@@ -117,7 +117,7 @@ extern "C"
 /* For backward compatibility */
 #define BROKER_INFO_MAJOR_VERSION               (BROKER_INFO_PROTO_VERSION)
 #define BROKER_INFO_MINOR_VERSION               (BROKER_INFO_FUNCTION_FLAG)
-#define BROKER_INFO_PATCH_VERSION               (BROKER_INFO_RESERVED2)
+#define BROKER_INFO_PATCH_VERSION               (BROKER_INFO_SYSTEM_PARAM)
 #define BROKER_INFO_RESERVED                    (BROKER_INFO_RESERVED3)
 
 #define CAS_PID_SIZE                            4
@@ -132,6 +132,9 @@ extern "C"
 
 #define CAS_STATEMENT_POOLING_OFF		0
 #define CAS_STATEMENT_POOLING_ON		1
+
+/* BITMASK for System Parameter */
+#define MASK_ORACLE_COMPAT_NUMBER_BEHAVIOR      0x01    // oracle_compat_number_behavior
 
 #define SHARD_ID_INVALID 		(-1)
 #define SHARD_ID_UNSUPPORTED	(-2)
@@ -209,7 +212,9 @@ extern "C"
     PROTOCOL_V8 = 8,		/* JSON type */
     PROTOCOL_V9 = 9,		/* cas health check: get function status */
     PROTOCOL_V10 = 10,		/* Secure Broker/CAS using SSL */
-    CURRENT_PROTOCOL = PROTOCOL_V10
+    PROTOCOL_V11 = 11,		/* make out resultset */
+    PROTOCOL_V12 = 12,		/* Remove trailing zeros from double and float types */
+    CURRENT_PROTOCOL = PROTOCOL_V12
   };
   typedef enum t_cas_protocol T_CAS_PROTOCOL;
 
@@ -221,7 +226,7 @@ extern "C"
     BROKER_INFO_CCI_PCONNECT,
     BROKER_INFO_PROTO_VERSION,
     BROKER_INFO_FUNCTION_FLAG,
-    BROKER_INFO_RESERVED2,
+    BROKER_INFO_SYSTEM_PARAM,
     BROKER_INFO_RESERVED3
   };
   typedef enum t_broker_info_pos T_BROKER_INFO_POS;

--- a/src/cci/cci_handle_mng.c
+++ b/src/cci/cci_handle_mng.c
@@ -1324,7 +1324,6 @@ init_con_handle (T_CON_HANDLE * con_handle, char *ip_str, int port, char *db_nam
   con_handle->ssl_handle.ctx = NULL;
   con_handle->useSSL = useSSL;
   con_handle->__gateway = false;
-  con_handle->oracle_style_number_return = false;
   con_handle->deferred_max_close_handle_count = DEFERRED_CLOSE_HANDLE_ALLOC_SIZE;
   con_handle->deferred_close_handle_list = (int *) MALLOC (sizeof (int) * con_handle->deferred_max_close_handle_count);
   con_handle->deferred_close_handle_count = 0;

--- a/src/cci/cci_properties.c
+++ b/src/cci/cci_properties.c
@@ -358,7 +358,6 @@ cci_conn_set_properties (T_CON_HANDLE * handle, char *properties)
      &handle->disconnect_on_query_timeout},
     {"useSSL", BOOL_PROPERTY, &handle->useSSL},
     {"__gateway", BOOL_PROPERTY, &handle->__gateway},
-    {"oracleStyleNumberReturn", BOOL_PROPERTY, &handle->oracle_style_number_return}
   };
   int error = CCI_ER_NO_ERROR;
 

--- a/src/cci/cci_query_execute.c
+++ b/src/cci/cci_query_execute.c
@@ -1687,6 +1687,8 @@ qe_get_data (T_CON_HANDLE * con_handle, T_REQ_HANDLE * req_handle, int col_no, i
   int data_size;
   int err_code;
   int num_cols;
+  T_BROKER_VERSION broker_ver;
+  bool is_oracle_style_number_return = false;
 
   if (req_handle->is_closed)
     {
@@ -1792,9 +1794,15 @@ qe_get_data (T_CON_HANDLE * con_handle, T_REQ_HANDLE * req_handle, int col_no, i
   switch (a_type)
     {
     case CCI_A_TYPE_STR:
+      broker_ver = hm_get_broker_version (con_handle);
+      if (hm_broker_understand_the_protocol (broker_ver, PROTOCOL_V12))
+	{
+	  is_oracle_style_number_return =
+	    con_handle->broker_info[BROKER_INFO_SYSTEM_PARAM] & MASK_ORACLE_COMPAT_NUMBER_BEHAVIOR;
+	}
       err_code =
 	qe_get_data_str (&(req_handle->conv_value_buffer), u_type, col_value_p, data_size, value, indicator,
-			 con_handle->oracle_style_number_return);
+			 is_oracle_style_number_return);
       break;
     case CCI_A_TYPE_BIGINT:
       err_code = qe_get_data_bigint (u_type, col_value_p, value);


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-977

Purpose
* to eliminate user confusion, 2-way expression is unified with the oracle_compat_number_behavior system parameter.
* in order for the broker to deliver the value of the system parameters including oracle_compat_number_behavior to the client, the broker extends the broker info that the client receives using the RESERVED field.
* Change the CAS Protocol version from PROTOCOL_V11 to PROTOCOL_V12 to express the extension of the above protocol

Implementation
N/A

Remarks
N/A