### PR TITLE
[APIS-993] add sym link for cas_cci.h and libcascci.so

### DIFF
--- a/cci/CMakeLists.txt
+++ b/cci/CMakeLists.txt
@@ -211,6 +211,13 @@ install(TARGETS cascci
   PUBLIC_HEADER DESTINATION ${CUBRID_CCIDIR}/include COMPONENT CCI
   )
 
+if(WITH_CCI AND UNIX)
+  file(CREATE_LINK "../cci/include/cas_cci.h" cas_cci.h SYMBOLIC)
+  install(FILES ${CMAKE_BINARY_DIR}/cas_cci.h DESTINATION ${CUBRID_INCLUDEDIR})
+  file(CREATE_LINK "../cci/lib/libcascci.so" libcascci.so SYMBOLIC)
+  install(FILES ${CMAKE_BINARY_DIR}/libcascci.so DESTINATION ${CUBRID_LIBDIR})
+endif(WITH_CCI AND UNIX)
+
 # install pdb files for debugging on windows
 if(WIN32)
   install(DIRECTORY


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-993

**Description**
* add symbolic to the CUBRID distribution as follow (**Linux only**):
  $CUBRID/include/cas_cci.h -> $CUBRID/cci/include/cas_cci.h
  $CUBRID/lib/libcascci.so -> $CUBRID/cci/lib/libcascci.so