### PR TITLE
[APIS-994] fix cci/cmake symlinks to be created at cmake_binary_dir instead of pwd

### DIFF
--- a/cci/CMakeLists.txt
+++ b/cci/CMakeLists.txt
@@ -212,9 +212,9 @@ install(TARGETS cascci
   )
 
 if(WITH_CCI AND UNIX)
-  file(CREATE_LINK "../cci/include/cas_cci.h" cas_cci.h SYMBOLIC)
+  file(CREATE_LINK "../cci/include/cas_cci.h" "${CMAKE_BINARY_DIR}/cas_cci.h" SYMBOLIC)
   install(FILES ${CMAKE_BINARY_DIR}/cas_cci.h DESTINATION ${CUBRID_INCLUDEDIR})
-  file(CREATE_LINK "../cci/lib/libcascci.so" libcascci.so SYMBOLIC)
+  file(CREATE_LINK "../cci/lib/libcascci.so" "${CMAKE_BINARY_DIR}/libcascci.so" SYMBOLIC)
   install(FILES ${CMAKE_BINARY_DIR}/libcascci.so DESTINATION ${CUBRID_LIBDIR})
 endif(WITH_CCI AND UNIX)
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-994


file 명령어로 생성되는 파일의 이름과

install 명령어로 설치되는 파일의 이름을 같게 하여

빌드 이식성을 높일 수 있습니다.

이 커밋을 통해 다시 명령어 실행 위치에 상관 없이 cmake로 cubrid를 빌드할 수 있게 됩니다.