### PR TITLE
[APIS-1074] Error handing for cci_fetch()

### DIFF
--- a/src/cci/cci_query_execute.c
+++ b/src/cci/cci_query_execute.c
@@ -1646,6 +1646,11 @@ qe_fetch (T_REQ_HANDLE * req_handle, T_CON_HANDLE * con_handle, char flag, int r
   err_code = net_recv_msg (con_handle, &result_msg, &result_msg_size, err_buf);
   if (err_code < 0)
     {
+      if (err_code == CCI_ER_DBMS || err_code == CCI_ER_COMMUNICATION) {
+        hm_req_handle_fetch_buf_free(req_handle);
+        req_handle->cursor_pos = 0;
+        req_handle->is_closed = 1;
+      }
       return err_code;
     }
 


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1074

Purpose
fetch 함수 사용 시 Critical 한 Error 사항에 대해서만 Resultset을 정리하도록 수정합니다.
(관련 이슈 : http://jira.cubrid.org/browse/CBRD-26218)

Implementation
- Close the result set if net_recv_msg fails(CCI_ER_DBMS, CCI_ER_COMMUNICATION) in qe_fetch.