### PR TITLE
[APIS-1060] used_flag should be clear at cci_xa_prepare

### DIFF
--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -4114,6 +4114,7 @@ cci_xa_prepare (int mapped_conn_id, XID * xid, T_CCI_ERROR * err_buf)
 
   set_error_buffer (&(con_handle->err_buf), error, NULL);
   get_last_error (con_handle, err_buf);
+  con_handle->used = false;
 
   return error;
 }
@@ -4155,6 +4156,7 @@ cci_xa_recover (int mapped_conn_id, XID * xid, int num_xid, T_CCI_ERROR * err_bu
 
   set_error_buffer (&(con_handle->err_buf), error, NULL);
   get_last_error (con_handle, err_buf);
+  con_handle->used = false;
 
   return error;
 }
@@ -4196,6 +4198,7 @@ cci_xa_end_tran (int mapped_conn_id, XID * xid, char type, T_CCI_ERROR * err_buf
 
   set_error_buffer (&(con_handle->err_buf), error, NULL);
   get_last_error (con_handle, err_buf);
+  con_handle->used = false;
 
   return error;
 }


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-1060

Purpose
XA기능에서 connection handle에 설정된 used flag를 클리어 하도록 수정.

Implementation
- add clear used flag in 'cci_xa_prepare', 'cci_xa_recover', 'cci_xa_end_tran'