### PR TITLE
[CBRD-26961] Add client->server stream transport protocol (COPY first consumer)

### DIFF
--- a/src/cci/broker_cas_protocol.h
+++ b/src/cci/broker_cas_protocol.h
@@ -188,8 +188,8 @@ extern "C"
     CAS_FC_CURSOR_CLOSE = 42,
     CAS_FC_GET_SHARD_INFO = 43,
     CAS_FC_CAS_CHANGE_MODE = 44,
-    CAS_FC_STREAM_SEND_DATA,	/* shared client->server byte-stream transport (COPY, internal-LOB, ...) */
-    CAS_FC_STREAM_END,
+    CAS_FC_STREAM_SEND_DATA = 45,
+    CAS_FC_STREAM_END = 46,
 
     /* Whenever you want to introduce a new function code, you must add a corresponding function entry to
      * server_fn_table of both CUBRID and (MySQL, Oracle). */

--- a/src/cci/broker_cas_protocol.h
+++ b/src/cci/broker_cas_protocol.h
@@ -188,6 +188,8 @@ extern "C"
     CAS_FC_CURSOR_CLOSE = 42,
     CAS_FC_GET_SHARD_INFO = 43,
     CAS_FC_CAS_CHANGE_MODE = 44,
+    CAS_FC_STREAM_SEND_DATA,	/* shared client->server byte-stream transport (COPY, internal-LOB, ...) */
+    CAS_FC_STREAM_END,
 
     /* Whenever you want to introduce a new function code, you must add a corresponding function entry to
      * server_fn_table of both CUBRID and (MySQL, Oracle). */
@@ -198,6 +200,11 @@ extern "C"
     CAS_FC_PREPARE_AND_EXECUTE_FOR_PROTO_V2 = 42
   };
   typedef enum t_cas_func_code T_CAS_FUNC_CODE;
+
+/* Compatibility aliases: COPY was the first consumer of the stream transport.
+ * The function-code values are unchanged (wire-compatible). */
+#define CAS_FC_COPY_SEND_DATA CAS_FC_STREAM_SEND_DATA
+#define CAS_FC_COPY_END       CAS_FC_STREAM_END
 
   enum t_cas_protocol
   {

--- a/src/cci/cas_cci.c
+++ b/src/cci/cas_cci.c
@@ -6678,3 +6678,70 @@ cci_get_cas_info (int mapped_conn_id, char *info_buf, int buf_length, T_CCI_ERRO
 
   return error;
 }
+
+int
+cci_stream_send_data (int mapped_conn_id, const char *data, int data_len, T_CCI_ERROR * err_buf)
+{
+  T_CON_HANDLE *con_handle = NULL;
+  int error = CCI_ER_NO_ERROR;
+
+  reset_error_buffer (err_buf);
+  if (data == NULL || data_len <= 0)
+    {
+      set_error_buffer (err_buf, CCI_ER_INVALID_ARGS, NULL);
+      return CCI_ER_INVALID_ARGS;
+    }
+
+  error = hm_get_connection (mapped_conn_id, &con_handle);
+  if (error != CCI_ER_NO_ERROR)
+    {
+      set_error_buffer (err_buf, error, NULL);
+      return error;
+    }
+  reset_error_buffer (&(con_handle->err_buf));
+
+  error = qe_stream_send_data (con_handle, data, data_len, &(con_handle->err_buf));
+
+  get_last_error (con_handle, err_buf);
+  con_handle->used = false;
+
+  return error;
+}
+
+int
+cci_stream_end (int mapped_conn_id, T_CCI_ERROR * err_buf)
+{
+  T_CON_HANDLE *con_handle = NULL;
+  int error = CCI_ER_NO_ERROR;
+
+  reset_error_buffer (err_buf);
+
+  error = hm_get_connection (mapped_conn_id, &con_handle);
+  if (error != CCI_ER_NO_ERROR)
+    {
+      set_error_buffer (err_buf, error, NULL);
+      return error;
+    }
+  reset_error_buffer (&(con_handle->err_buf));
+
+  error = qe_stream_end (con_handle, &(con_handle->err_buf));
+
+  get_last_error (con_handle, err_buf);
+  con_handle->used = false;
+
+  return error;
+}
+
+/* Back-compat: COPY was the first consumer of the stream transport.
+ * These forward to the generalized cci_stream_* entry points. */
+int
+cci_copy_send_data (int mapped_conn_id, const char *data, int data_len, T_CCI_ERROR * err_buf)
+{
+  return cci_stream_send_data (mapped_conn_id, data, data_len, err_buf);
+}
+
+int
+cci_copy_end (int mapped_conn_id, T_CCI_ERROR * err_buf)
+{
+  return cci_stream_end (mapped_conn_id, err_buf);
+}

--- a/src/cci/cas_cci.h
+++ b/src/cci/cas_cci.h
@@ -980,6 +980,13 @@ extern "C"
   extern int cci_is_shard (int con_h_id, T_CCI_ERROR * err_buf);
   extern int cci_get_cas_info (int mapped_conn_id, char *info_buf, int buf_length, T_CCI_ERROR * err_buf);
 
+  extern int cci_stream_send_data (int mapped_conn_id, const char *data, int data_len, T_CCI_ERROR * err_buf);
+  extern int cci_stream_end (int mapped_conn_id, T_CCI_ERROR * err_buf);
+
+  /* Back-compat aliases: COPY was the first consumer of the stream transport. */
+  extern int cci_copy_send_data (int mapped_conn_id, const char *data, int data_len, T_CCI_ERROR * err_buf);
+  extern int cci_copy_end (int mapped_conn_id, T_CCI_ERROR * err_buf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/cci/cci_query_execute.c
+++ b/src/cci/cci_query_execute.c
@@ -7375,3 +7375,76 @@ get_charset_type (char type)
     }
   return charset;
 }
+
+int
+qe_stream_send_data (T_CON_HANDLE * con_handle, const char *data, int data_len, T_CCI_ERROR * err_buf)
+{
+  T_NET_BUF net_buf;
+  char func_code = CAS_FC_STREAM_SEND_DATA;
+  int err_code;
+  char *result_msg = NULL;
+  int result_msg_size;
+
+  net_buf_init (&net_buf);
+  net_buf_cp_str (&net_buf, &func_code, 1);
+
+  ADD_ARG_BYTES (&net_buf, data, data_len);
+  if (net_buf.err_code < 0)
+    {
+      err_code = net_buf.err_code;
+      net_buf_clear (&net_buf);
+      return err_code;
+    }
+
+  err_code = net_send_msg (con_handle, net_buf.data, net_buf.data_size);
+  net_buf_clear (&net_buf);
+  if (err_code < 0)
+    {
+      return err_code;
+    }
+
+  err_code = net_recv_msg (con_handle, &result_msg, &result_msg_size, err_buf);
+  FREE_MEM (result_msg);
+
+  return err_code;
+}
+
+int
+qe_stream_end (T_CON_HANDLE * con_handle, T_CCI_ERROR * err_buf)
+{
+  T_NET_BUF net_buf;
+  char func_code = CAS_FC_STREAM_END;
+  int err_code;
+  char *result_msg = NULL;
+  int result_msg_size;
+  int rows_loaded = 0;
+
+  net_buf_init (&net_buf);
+  net_buf_cp_str (&net_buf, &func_code, 1);
+
+  if (net_buf.err_code < 0)
+    {
+      err_code = net_buf.err_code;
+      net_buf_clear (&net_buf);
+      return err_code;
+    }
+
+  err_code = net_send_msg (con_handle, net_buf.data, net_buf.data_size);
+  net_buf_clear (&net_buf);
+  if (err_code < 0)
+    {
+      return err_code;
+    }
+
+  err_code = net_recv_msg (con_handle, &result_msg, &result_msg_size, err_buf);
+  if (err_code >= 0 && result_msg != NULL && result_msg_size >= NET_SIZE_INT)
+    {
+      char *ptr = result_msg;
+      NET_STR_TO_INT (rows_loaded, ptr);
+      err_code = rows_loaded;
+    }
+
+  FREE_MEM (result_msg);
+
+  return err_code;
+}

--- a/src/cci/cci_query_execute.h
+++ b/src/cci/cci_query_execute.h
@@ -497,6 +497,9 @@ extern int qe_lob_write (T_CON_HANDLE * con_handle, T_LOB * lob, INT64 start_pos
 extern int qe_lob_read (T_CON_HANDLE * con_handle, T_LOB * lob, INT64 start_pos, int length, char *buf,
 			T_CCI_ERROR * err_buf);
 
+extern int qe_stream_send_data (T_CON_HANDLE * con_handle, const char *data, int data_len, T_CCI_ERROR * err_buf);
+extern int qe_stream_end (T_CON_HANDLE * con_handle, T_CCI_ERROR * err_buf);
+
 extern int qe_get_shard_info (T_CON_HANDLE * con_handle, T_CCI_SHARD_INFO ** shard_info, T_CCI_ERROR * err_buf);
 extern int qe_shard_info_free (T_CCI_SHARD_INFO * shard_info);
 extern int qe_is_shard (T_CON_HANDLE * con_handle);


### PR DESCRIPTION
<http://jira.cubrid.org/browse/CBRD-26961>

### Purpose

Add a consumer-agnostic **client→server byte-stream transport** to CCI so consumers
(starting with `COPY <table> FROM STDIN`, and later internal-LOB input) share one wire
path instead of re-implementing it. This is the CCI half of the server-side stream
transport ([CBRD-26961]); the on-wire protocol is unchanged.

### Implementation

- **CAS function codes** `CAS_FC_COPY_SEND_DATA` / `CAS_FC_COPY_END` →
  `CAS_FC_STREAM_SEND_DATA` / `CAS_FC_STREAM_END` with **identical numeric values**
  (ordinals 45/46, after `CAS_FC_CAS_CHANGE_MODE = 44`). `CAS_FC_COPY_*` are kept as
  `#define` aliases. This matches the server rename and keeps the wire compatible.
- **Public API**: `cci_stream_send_data()` / `cci_stream_end()` are the canonical entry
  points. `cci_copy_send_data()` / `cci_copy_end()` remain as thin back-compat wrappers
  that forward to them, so existing callers keep working.
- **Internal**: `qe_copy_*` renamed to `qe_stream_*`.

### Remarks

- **Build-verified** (x86_64/release): full compile + link, `libcascci.so` produced.
- **Wire unchanged** — values identical, COPY aliases retained → server and existing
  drivers stay compatible.
- Pairs in lockstep with the server PR ([CUBRID/cubrid#7343]). After this merges, the
  server submodule pointer is bumped to the merged cci develop SHA.
